### PR TITLE
Api now respond with the same JSON in every cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ build/
 .project
 .settings/
 .externalToolBuilders/
+it-dgc-verificac19-spring-rest-api/bin/

--- a/it-dgc-verificac19-spring-rest-api/pom.xml
+++ b/it-dgc-verificac19-spring-rest-api/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>it.dgc</groupId>
 	<artifactId>it-dgc-verificac19-spring-rest-api</artifactId>
-	<version>0.0.3</version>
+	<version>0.1.0</version>
 	<name>it-dgc-verificac19-spring-rest-api</name>
 	<description>dgc Verifier REST API</description>
 	<properties>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>it.dgc</groupId>
 			<artifactId>it-dgc-verificac19-spring-core</artifactId>
-			<version>${project.version}</version>
+			<version>0.0.3</version>
 		</dependency>
 
 		<dependency>

--- a/it-dgc-verificac19-spring-rest-api/src/main/java/it/dgc/verificac19/models/ApiResponse.java
+++ b/it-dgc-verificac19-spring-rest-api/src/main/java/it/dgc/verificac19/models/ApiResponse.java
@@ -1,0 +1,66 @@
+/**
+ * 
+ */
+package it.dgc.verificac19.models;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import it.dgc.verificac19.model.CertificateSimple;
+
+public class ApiResponse {
+
+	private MessageCode messageCode;
+	private CertificateSimple certificate;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "CET")
+	private LocalDateTime serverTime = LocalDateTime.now();
+	
+	private enum MessageCode {
+		OK, UPDATE_DRL_IN_PROGRESS, CANNOT_DECODE_IMAGE
+	}
+	
+
+	public CertificateSimple getCertificate() {
+		return certificate;
+	}
+	
+	public MessageCode getMessageCode() {
+		return messageCode;
+	}
+	
+	public LocalDateTime getServerTime() {
+		return serverTime;
+	}
+	
+	private void setMessageCode(MessageCode messageCode) {
+		this.messageCode = messageCode;
+	}
+	
+	private void setCertificate(CertificateSimple certificate) {
+		this.certificate = certificate;
+	}
+	
+	public static ApiResponse buildOkResponse(CertificateSimple certificate) {
+		ApiResponse toReturn = new ApiResponse();
+		toReturn.setCertificate(certificate);
+		toReturn.setMessageCode(MessageCode.OK);
+		return toReturn;
+	}
+	
+	public static ApiResponse buildUpdatingResponse() {
+		ApiResponse toReturn = new ApiResponse();
+		toReturn.setMessageCode(MessageCode.UPDATE_DRL_IN_PROGRESS);
+		return toReturn;
+	}
+	
+	public static ApiResponse buildDecodeError() {
+		ApiResponse toReturn = new ApiResponse();
+		toReturn.setMessageCode(MessageCode.CANNOT_DECODE_IMAGE);
+		return toReturn;
+	}
+	
+	
+	
+}
+	

--- a/it-dgc-verificac19-spring-rest-api/src/main/java/it/dgc/verificac19/rest/VerifierRestApi.java
+++ b/it-dgc-verificac19-spring-rest-api/src/main/java/it/dgc/verificac19/rest/VerifierRestApi.java
@@ -6,9 +6,11 @@ import java.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,78 +19,74 @@ import org.springframework.web.multipart.MultipartFile;
 import it.dgc.verificac19.data.local.Preferences;
 import it.dgc.verificac19.model.CertificateSimple;
 import it.dgc.verificac19.model.ValidationScanMode;
+import it.dgc.verificac19.models.ApiResponse;
 import it.dgc.verificac19.service.VerifierService;
 
 @RestController
 @RequestMapping(value = "api")
 public class VerifierRestApi {
 
-  private static final Logger LOG = LoggerFactory.getLogger(VerifierRestApi.class);
+	private static final Logger logger = LoggerFactory.getLogger(VerifierRestApi.class);
 
-  @Autowired
-  VerifierService verifierService;
+	@Autowired
+	VerifierService verifierService;
 
-  @Autowired
-  Preferences preferences;
+	@Autowired
+	Preferences preferences;
 
-  @RequestMapping(value = "/verify-string", method = RequestMethod.GET)
-  public ResponseEntity<CertificateSimple> verifyByString(
-      @RequestParam(name = "qrCodeTxt", required = true) String qrCodeTxt,
-      @RequestParam(name = "scanMode", required = false) ValidationScanMode inputScanMode) {
+	@GetMapping(value = "/verify-string")
+	public ResponseEntity<ApiResponse> verifyByString(
+			@RequestParam(name = "qrCodeTxt", required = true) String qrCodeTxt,
+			@RequestParam(name = "scanMode", required = false) ValidationScanMode inputScanMode) {
 
-    if (preferences.getDateLastFetch() == null
-        || !preferences.getDateLastFetch().toLocalDate().isEqual(LocalDate.now())) {
-      LOG.info("Not updated");
-      return ResponseEntity.ok().build();
-    } else {
-    final ValidationScanMode actualScanMode = inputScanMode == null ? ValidationScanMode.NORMAL_DGP : inputScanMode;
-    	
-    CertificateSimple certificateSimple = verifierService.verify(qrCodeTxt, actualScanMode);
+		if (preferences.getDateLastFetch() == null
+				|| !preferences.getDateLastFetch().toLocalDate().isEqual(LocalDate.now())) {
+			logger.info("DRL not updated yet");
+			return new ResponseEntity<>(ApiResponse.buildUpdatingResponse(), HttpStatus.OK);
+		} else {
+			final ValidationScanMode actualScanMode = inputScanMode == null ? ValidationScanMode.NORMAL_DGP
+					: inputScanMode;
 
-    switch (certificateSimple.getCertificateStatus()) {
-      case NOT_EU_DCC:
-      case NOT_VALID:
-      case NOT_VALID_YET:
-        LOG.info("Invalid");
-        break;
-      case VALID:
-        LOG.info("Valid");
-        break;
-    }
-    return ResponseEntity.ok(certificateSimple);
-    }
-  }
+			CertificateSimple validatedCertificate = verifierService.verify(qrCodeTxt, actualScanMode);
+			VerifierRestApi.logResponse(validatedCertificate);
+			return new ResponseEntity<>(ApiResponse.buildOkResponse(validatedCertificate), HttpStatus.OK);
+		}
+	}
 
-  @RequestMapping(value = "/verify-image", method = RequestMethod.POST)
-  public ResponseEntity<CertificateSimple> verifyByImage(@RequestPart(name = "file", required = true) MultipartFile file, 
-		  @RequestParam(name = "scanMode", required = true) ValidationScanMode inputScanMode) {
-    if (preferences.getDateLastFetch() == null
-        || !preferences.getDateLastFetch().toLocalDate().isEqual(LocalDate.now())) {
-      LOG.info("Not updated");
-      return ResponseEntity.ok().build();
-    } else {
-      final ValidationScanMode actualScanMode = inputScanMode == null ? ValidationScanMode.NORMAL_DGP : inputScanMode;
+	@PostMapping(value = "/verify-image")
+	public ResponseEntity<ApiResponse> verifyByImage(@RequestPart(name = "file", required = true) MultipartFile file,
+			@RequestParam(name = "scanMode", required = true) ValidationScanMode inputScanMode) {
+		if (preferences.getDateLastFetch() == null
+				|| !preferences.getDateLastFetch().toLocalDate().isEqual(LocalDate.now())) {
+			logger.info("DRL not updated yet");
+			return ResponseEntity.ok().build();
+		} else {
+			final ValidationScanMode actualScanMode = inputScanMode == null ? ValidationScanMode.NORMAL_DGP
+					: inputScanMode;
 
-      CertificateSimple certificateSimple;
-      try {
-        certificateSimple = verifierService.verify(file.getBytes(), actualScanMode);
-      } catch (IOException e) {
-        LOG.error("Error on decode image", e);
-        return ResponseEntity.internalServerError().build();
-      }
+			CertificateSimple validatedCertificate;
+			try {
+				validatedCertificate = verifierService.verify(file.getBytes(), actualScanMode);
+			} catch (IOException e) {
+				return new ResponseEntity<>(ApiResponse.buildDecodeError(), HttpStatus.BAD_REQUEST);
 
-      switch (certificateSimple.getCertificateStatus()) {
-        case NOT_EU_DCC:
-        case NOT_VALID:
-        case NOT_VALID_YET:
-          LOG.info("Invalid");
-          break;
-        case VALID:
-          LOG.info("Valid");
-          break;
-      }
-      return ResponseEntity.ok(certificateSimple);
-    }
-  }
+			}
+			VerifierRestApi.logResponse(validatedCertificate);
+			return new ResponseEntity<>(ApiResponse.buildOkResponse(validatedCertificate), HttpStatus.OK);
+		}
+	}
 
+	private static void logResponse(CertificateSimple certificateSimple) {
+		switch (certificateSimple.getCertificateStatus()) {
+		case NOT_EU_DCC:
+		case NOT_VALID:
+		case NOT_VALID_YET:
+		case TEST_NEEDED:
+			logger.info("Invalid");
+			break;
+		case VALID:
+			logger.info("Valid");
+			break;
+		}
+	}
 }


### PR DESCRIPTION
Ho fatto un paio di fix (non veniva loggato "NOT VALID" in caso di stato del certificato "TEST_NEEDED", aggiunto con l'altra PR) e le due API di demo rispondono sempre con lo stesso formato, se interessa!